### PR TITLE
Add fields legalEntityCredential and qviCredential back into outbound payload for OOR issuance,

### DIFF
--- a/src/sally/core/handling.py
+++ b/src/sally/core/handling.py
@@ -213,7 +213,7 @@ class Communicator(doing.DoDoer):
                     elif creder.schema == LE_SCHEMA:
                         data = self.entityPayload(creder)
                     elif creder.schema == OOR_SCHEMA:
-                        data = self.roleCredentialPayload(creder)
+                        data = self.roleCredentialPayload(self.reger, creder)
                     else:
                         raise kering.ValidationError("this will never happen because all credentials that get here are"
                                                      " valid")
@@ -439,10 +439,18 @@ class Communicator(doing.DoDoer):
         return data
 
     @staticmethod
-    def roleCredentialPayload(creder):
+    def roleCredentialPayload(reger, creder):
         a = creder.crd["a"]
         edges = creder.chains
         asaid = edges["auth"]["n"]
+
+        auth = reger.creds.get(asaid)
+        aedges = auth.chains
+        lesaid = aedges["le"]["n"]
+        qvi = reger.creds.get(lesaid)
+        qedges = qvi.chains
+        qsaid = qedges["qvi"]["n"]
+
         data = dict(
             schema=creder.schema,
             issuer=creder.issuer,
@@ -450,6 +458,8 @@ class Communicator(doing.DoDoer):
             credential=creder.said,
             recipient=a["i"],
             authCredential=asaid,
+            qviCredential=qsaid,
+            legalEntityCredential=lesaid,
             LEI=a["LEI"],
             personLegalName=a["personLegalName"],
             officialRole=a["officialRole"]

--- a/tests/core/test_handling.py
+++ b/tests/core/test_handling.py
@@ -170,8 +170,10 @@ def test_communicator(seeder, mockHelpingNowUTC):
                                  'credential': 'EHZ05NsGCdWNujHTK3FqyuPmR8qz04Q3xg3Hnz1hkPmm',
                                  'issueTimestamp': '2021-01-01T00:00:00.000000+00:00',
                                  'issuer': 'EOwXzTKWgsmCDVJwMS4VUJWX-m-oKx9d8VDyaRNY6mMZ',
+                                 'legalEntityCredential': 'EL5nGzlXb8DEjFh4pOZMd7F10NYfX7inyci3iw9juY6_',
                                  'officialRole': 'Baba Yaga',
                                  'personLegalName': 'John Wick',
+                                 'qviCredential': 'EIbjVgfyrIj_jVjpgZXu2D-FFwWIc-pCFWnNd3F_vrD2',
                                  'recipient': 'EIf2fK7M9Mfd-Twv2Ig3n8PpGM_p976mciznHoknVPLs',
                                  'schema': 'EBNaNu-M9P5cgrnfl2Fvymy4E_jvxxyjb70PRtiANlJy'}}
 


### PR DESCRIPTION
Upstream application still unable to update to this change.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>