### PR TITLE
Check whether the QVI credential has been revoked or not

### DIFF
--- a/src/sally/core/handling.py
+++ b/src/sally/core/handling.py
@@ -405,6 +405,12 @@ class Communicator(doing.DoDoer):
         if qcreder is None:
             raise kering.ValidationError(f"QVI credential {qsaid} not found for credential {creder.said}")
 
+        qregk = qcreder.status
+        qstate = self.reger.tevers[qregk].vcState(qcreder.said)
+        if qstate is None or qstate.ked['et'] not in (coring.Ilks.iss, coring.Ilks.bis):
+            raise kering.ValidationError(
+                f"QVI credential {qcreder.said} of the presented {creder.said} has been revoked")
+
         self.validateQualifiedvLEIIssuer(qcreder)
 
     @staticmethod


### PR DESCRIPTION
When verifying the LE credential, we need to check its edge (parent) QVI credential to ensure it has not been revoked.