### PR TITLE
Upgrade to KERI 1.1.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='sally',
-    version='0.0.1',  # also change in src/sally/__init__.py
+    version='0.1.0',  # also change in src/sally/__init__.py
     license='Apache Software License 2.0',
     description='vLEI Audit Reporting API',
     long_description="vLEI auditing server that responds to credential presentations by signaling via webhooks.",
@@ -52,7 +52,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         # uncomment if you test on these interpreters:
         # 'Programming Language :: Python :: Implementation :: PyPy',
@@ -69,20 +69,20 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=3.10.13',
+    python_requires='>=3.11.6',
     install_requires=[
-        'keri>=1.1.8',
-        'hio>=0.6.8',
+        'keri>=1.1.21',
+        'hio>=0.6.14',
         'multicommand>=1.0.0',
-        'blake3>=0.3.1',
-        'falcon>=3.1.0',
-        'http_sfv>=0.9.8'
+        'blake3>=0.4.1',
+        'falcon>=3.1.3',
+        'http_sfv>=0.9.9'
     ],
     extras_require={
     },
     tests_require=[
-        'coverage>=5.5',
-        'pytest>=6.2.5',
+        'coverage>=7.4.4',
+        'pytest>=8.1.1',
         'pytest-mock-server>=0.3.0'
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,8 @@ setup(
     ],
     python_requires='>=3.11.6',
     install_requires=[
-        'keri>=1.1.21',
-        'hio>=0.6.14',
+        'cit-keri>=1.1.22rc1',
+        'cit-hio>=0.6.14',
         'multicommand>=1.0.0',
         'blake3>=0.4.1',
         'falcon>=3.1.3',

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,4 @@ sally package
 
 """
 
-__version__ = '0.0.1'  # also change in setup.py
+__version__ = '0.1.0'  # also change in setup.py

--- a/src/sally/app/cli/commands/version.py
+++ b/src/sally/app/cli/commands/version.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+"""
+sally.app.cli.commands module
+
+"""
+import argparse
+
+from hio.base import doing
+from keri.app import directing
+
+import sally
+from keri.app.cli.common import existing
+
+parser = argparse.ArgumentParser(description='Print version of sally CLI')
+parser.set_defaults(handler=lambda args: handler(args))
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=False,
+                    default=None)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+
+def handler(args):
+    kwa = dict(args=args)
+    doers = [doing.doify(version, **kwa)]
+    directing.runController(doers=doers, expire=0.0)
+
+
+def version(tymth, tock=0.0, **opts):
+    """ Command line version handler
+    """
+    _ = (yield tock)
+
+    args = opts["args"]
+    name = args.name
+    base = args.base
+    bran = args.bran
+
+    print(f"Library version: {sally.__version__}")
+
+    if name is not None:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            print(f"Database version: {hby.db.version}")


### PR DESCRIPTION
This upgrades KERIpy to 1.1.21 and HIO to 0.6.14 and all of the other dependencies to match KERIpy.

It also adds a `sally version` command.