### PR TITLE
feat,chore: enable clearing escrows; keri 1.1.22; version cmd

### DIFF
--- a/.github/workflows/sally-ci.yml
+++ b/.github/workflows/sally-ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.12.1
+      - name: Set up Python 3.12.2
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12.1
+          python-version: 3.12.2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='sally',
-    version='0.0.1',  # also change in src/sally/__init__.py
+    version='0.1.0',  # also change in src/sally/__init__.py
     license='Apache Software License 2.0',
     description='vLEI Audit Reporting API',
     long_description="vLEI auditing server that responds to credential presentations by signaling via webhooks.",
@@ -52,7 +52,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         # uncomment if you test on these interpreters:
         # 'Programming Language :: Python :: Implementation :: PyPy',
@@ -69,20 +69,20 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=3.10.13',
+    python_requires='>=3.12.2',
     install_requires=[
-        'keri>=1.1.8',
-        'hio>=0.6.8',
+        'keri>=1.1.22',
+        'hio>=0.6.14',
         'multicommand>=1.0.0',
-        'blake3>=0.3.1',
-        'falcon>=3.1.0',
-        'http_sfv>=0.9.8'
+        'blake3>=0.4.1',
+        'falcon>=3.1.3',
+        'http_sfv>=0.9.9'
     ],
     extras_require={
     },
     tests_require=[
-        'coverage>=5.5',
-        'pytest>=6.2.5',
+        'coverage>=7.4.4',
+        'pytest>=8.1.1',
         'pytest-mock-server>=0.3.0'
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     ],
     python_requires='>=3.12.2',
     install_requires=[
-        'keri>=1.1.22',
+        'keri>=1.1.22, < 1.2.0',
         'hio>=0.6.14',
         'multicommand>=1.0.0',
         'blake3>=0.4.1',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='sally',
-    version='0.1.0',  # also change in src/sally/__init__.py
+    version='0.9.2',  # also change in src/sally/__init__.py
     license='Apache Software License 2.0',
     description='vLEI Audit Reporting API',
     long_description="vLEI auditing server that responds to credential presentations by signaling via webhooks.",

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,4 @@ sally package
 
 """
 
-__version__ = '0.0.1'  # also change in setup.py
+__version__ = '0.1.0'  # also change in setup.py

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,4 @@ sally package
 
 """
 
-__version__ = '0.1.0'  # also change in setup.py
+__version__ = '0.9.2'  # also change in setup.py

--- a/src/sally/app/cli/commands/server/start.py
+++ b/src/sally/app/cli/commands/server/start.py
@@ -9,6 +9,8 @@ import logging
 from keri import help
 from keri.app import keeping, habbing, directing, configing, oobiing
 from keri.app.cli.common import existing
+
+import sally
 from sally.core import serving
 
 help.ogler.level = logging.getLevelName(logging.INFO)
@@ -105,5 +107,6 @@ def launch(args, expire=0.0):
     doers += serving.setup(hby, alias=alias, httpPort=http_port, hook=hook, auth=auth,
                            listen=listen, timeout=timeout, retry=retry)
 
+    logger.info(f"Sally server version {sally.__version__} and database version {hby.db.version}")
     logger.info(f"Sally Server listening on {http_port}")
     directing.runController(doers=doers, expire=expire)

--- a/src/sally/app/cli/commands/version.py
+++ b/src/sally/app/cli/commands/version.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+"""
+sally.app.cli.commands module
+"""
+import argparse
+
+from hio.base import doing
+from keri.app import directing
+
+import sally
+from keri.app.cli.common import existing
+
+parser = argparse.ArgumentParser(description='Print version of sally CLI')
+parser.set_defaults(handler=lambda args: handler(args))
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=False,
+                    default=None)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+
+def handler(args):
+    kwa = dict(args=args)
+    doers = [doing.doify(version, **kwa)]
+    directing.runController(doers=doers, expire=0.0)
+
+
+def version(tymth, tock=0.0, **opts):
+    """ Command line version handler
+    """
+    _ = (yield tock)
+
+    args = opts["args"]
+    name = args.name
+    base = args.base
+    bran = args.bran
+
+    print(f"Library version: {sally.__version__}")
+
+    if name is not None:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            print(f"Database version: {hby.db.version}")

--- a/src/sally/core/basing.py
+++ b/src/sally/core/basing.py
@@ -5,9 +5,11 @@ sally.core.basing module
 
 Database support
 """
+from keri import help
 from keri.core import coring, serdering
 from keri.db import dbing, subing
 
+logger = help.ogler.getLogger()
 
 class CueBaser(dbing.LMDBer):
     """
@@ -65,3 +67,11 @@ class CueBaser(dbing.LMDBer):
         self.ack = subing.SerderSuber(db=self, subkey="ack", klas=serdering.SerderACDC)
 
         return self.env
+
+    def clearEscrows(self):
+        """
+        Clear all credential escrows. Useful in testing to avoid many unneeded log messages or force reprocessing of presentations.
+        """
+        self.iss.trim()
+        self.rev.trim()
+        logger.info("Cleared iss and rev escrows")

--- a/src/sally/core/serving.py
+++ b/src/sally/core/serving.py
@@ -55,7 +55,7 @@ def setup(hby, *, alias, httpPort, hook, auth, listen=False, timeout=10, retry=3
     verifier = verifying.Verifier(hby=hby, reger=reger)
 
     cdb = basing.CueBaser(name=hby.name)
-    if env_var_to_bool("CLEAR_ESCROWS", False):
+    if env_var_to_bool("CLEAR_ESCROWS", True):
         logger.info("Clearing escrows")
         cdb.clearEscrows()
 

--- a/src/sally/core/serving.py
+++ b/src/sally/core/serving.py
@@ -5,6 +5,7 @@ sally.core.serving module
 
 Endpoint service
 """
+import os
 
 import falcon
 from base64 import urlsafe_b64encode as encodeB64
@@ -52,7 +53,12 @@ def setup(hby, *, alias, httpPort, hook, auth, listen=False, timeout=10, retry=3
     reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
     rep = storing.Respondant(hby=hby, mbx=mbx)
     verifier = verifying.Verifier(hby=hby, reger=reger)
+
     cdb = basing.CueBaser(name=hby.name)
+    if env_var_to_bool("CLEAR_ESCROWS", False):
+        logger.info("Clearing escrows")
+        cdb.clearEscrows()
+
     comms = handling.Communicator(hby=hby,
                                   hab=hab,
                                   cdb=cdb,
@@ -110,6 +116,8 @@ def setup(hby, *, alias, httpPort, hook, auth, listen=False, timeout=10, retry=3
 
     return doers
 
+def env_var_to_bool(var_name, default=False):
+    return os.getenv(var_name, default).lower() in ["true", "1"]
 
 class TeveryCuery(doing.Doer):
 

--- a/tests/core/test_basing.py
+++ b/tests/core/test_basing.py
@@ -31,6 +31,6 @@ def test_baser():
     assert isinstance(baser.revk, subing.SerderSuber)
     assert isinstance(baser.ack, subing.SerderSuber)
 
-    assert baser.env.stat()['entries'] == 6
+    assert baser.env.stat()['entries'] == 7  # One for each DB above and then one for the version field, __version__
 
 


### PR DESCRIPTION
This does a few things:
1. Enables clearing of the issuance and revocation presentation escrows 'iss' and 'rev' with the `CLEAR_ESCROWS` environment variable.
2. Upgrades KERI to version 1.1.22.
3. Bumps the Sally version from 0.0.1 to 0.1.0.
4. Adds a `sally version` command so it is easy to show the deployed version of Sally.
5. Shows the Sally version and KERI database version on startup.