### PR TITLE
feat, docs: enhanced webhook and handler docs

### DIFF
--- a/src/sally/app/cli/commands/hook/demo.py
+++ b/src/sally/app/cli/commands/hook/demo.py
@@ -5,11 +5,14 @@ sally.cli.commands module
 """
 import argparse
 import logging
+import pprint
 
 import falcon
 from hio.core import http
 from keri import help
 from keri.app import directing
+
+from sally.core import handling
 
 logger = help.ogler.getLogger()
 
@@ -19,7 +22,7 @@ parser.set_defaults(handler=lambda args: launch(args),
 parser.add_argument('-p', '--http',
                     action='store',
                     default=9923,
-                    help="Port on which to listen for web hook event.  Defaults to 9923")
+                    help="Port on which to listen for web hook events.  Defaults to 9923")
 
 
 def launch(args, expire=0.0):
@@ -36,7 +39,7 @@ def launch(args, expire=0.0):
             allow_origins='*',
             allow_credentials='*',
             expose_headers=['cesr-attachment', 'cesr-date', 'content-type']))
-    app.add_route("/", Listener())
+    app.add_route("/", WebhookListener())
 
     server = http.Server(port=httpPort, app=app)
     httpServerDoer = http.ServerDoer(server=server)
@@ -45,24 +48,73 @@ def launch(args, expire=0.0):
     directing.runController(doers=[httpServerDoer], expire=expire)
 
 
-class Listener:
+class WebhookListener:
     """
-    Endpoint for web hook calls that prints events to stdout
+    Demonstration endpoint for web hook calls that prints events to stdout and stores a simple presentation cache.
     """
+    def __init__(self):
+        self.received = dict()
 
-    def on_post(self, req, rep):
-        """ Responds to web hook event POSTs by printing the results to stdout
-
+    def on_post(self, req, resp):
+        """Receives web hook POST events by printing the credential results to stdout and storing presentations them in memory
         Parameters:
             req: falcon.Request HTTP request
             rep: falcon.Response HTTP response
-
         """
         logger.info("** HEADERS **")
-        logger.info(req.headers)
+        logger.info(pprint.pprint(req.headers))
         logger.info("*************")
 
         logger.info("**** BODY ****")
         body = req.get_media()
-        logger.info(body)
+        logger.info(pprint.pprint(body))
         logger.info("**************")
+
+        data = body.get("data", {})
+        if not data:
+            logger.error("No data in body")
+            resp.media = {"error": "No data in body"}
+            resp.status = falcon.HTTP_400
+            return
+        type = self._resolve_type(data["schema"])
+        if type == "OOR":
+            holder = data.get("recipient", "")
+            presentation = dict(
+                credential=data.get("credential", ""),
+                type=type,
+                issuer=body.get("actor", ""),
+                holder=holder,
+                LEI=data.get("LEI", ""),
+                personLegalName=data.get("personLegalName", ""),
+                officialRole=data.get("officialRole", ""),
+            )
+            self.received[holder] = presentation
+        resp.status = falcon.HTTP_202
+
+    def _resolve_type(self, schema_said):
+        """Return human friendly name for schema type"""
+        match schema_said:
+            case handling.QVI_SCHEMA:
+                return "QVI"
+            case handling.LE_SCHEMA:
+                return "LE"
+            case handling.OOR_AUTH_SCHEMA:
+                return "OOR Auth"
+            case handling.OOR_SCHEMA:
+                return "OOR"
+            case _:
+                raise ValueError(f"Unknown schema type with SAID: {schema_said}")
+
+    def on_get(self, req, resp):
+        """
+        Tells the presenter if they have presented a credential before.
+        Used in testing to determine that a presentation has succeeded.
+        """
+        holder = req.get_param("holder", required=True)
+        if holder in self.received:
+            resp.media = self.received[holder]
+            resp.status = falcon.HTTP_200
+        else:
+            resp.media = {"error": f"No credential presented by {holder}"}
+            resp.status = falcon.HTTP_404
+


### PR DESCRIPTION
This adds a new webhook route at GET `/?{holder-AID}` to see if a particular holder has made a presentation already. It only keeps track of the latest presentation for a holder, not all presentations, and is just in memory. This is a convenience added so that shell scripts can easily detect with a while loop whether a presentation to Sally has been successful or not.

This also adds a lot of documentation to Sally, especially the PresentationProofHandler.recur function.