### PR TITLE
feat: upgrade to KERI 1.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,22 @@ https://caremad.io/posts/2013/07/setup-vs-requirement/
 from glob import glob
 from os.path import basename
 from os.path import splitext
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
+this_directory = Path(__file__).parent
+if (this_directory / "README.md").exists():  # If building inside a container, like in the `images/keria.dockerfile`, this file won't exist and fails the build
+    long_description = (this_directory / "README.md").read_text()
+else:
+    long_description = "vLEI auditing server that responds to credential presentations by signaling via webhooks."
+
 setup(
     name='sally',
-    version='0.9.3',  # also change in src/sally/__init__.py
+    version='0.9.4',  # also change in src/sally/__init__.py
     license='Apache Software License 2.0',
     description='vLEI Audit Reporting API',
-    long_description="vLEI auditing server that responds to credential presentations by signaling via webhooks.",
+    long_description=long_description,
     author='Philip S. Feairheller',
     author_email='pfeairheller@gmail.com',
     url='https://github.com/GLEIF-IT/sally',
@@ -71,21 +78,24 @@ setup(
     ],
     python_requires='>=3.12.2',
     install_requires=[
-        'keri>=1.1.22, < 1.2.0',
-        'hio>=0.6.14',
-        'multicommand>=1.0.0',
-        'blake3>=0.4.1',
-        'falcon>=3.1.3',
+        'keri==1.2.4',
+        'hio==0.6.14',
+        'multicommand==1.0.0',
+        'blake3==0.4.1',
+        'falcon==4.0.2',
         'http_sfv>=0.9.9'
     ],
     extras_require={
+        'test': ['pytest', 'coverage', 'pytest-mock-server'],
+        'docs': ['sphinx', 'sphinx-rtd-theme']
     },
     tests_require=[
-        'coverage>=7.4.4',
-        'pytest>=8.1.1',
-        'pytest-mock-server>=0.3.0'
+        'coverage>=7.6.10',
+        'pytest>=8.3.4',
+        'pytest-mock-server>=0.3.2'
     ],
     setup_requires=[
+        'setuptools==75.8.0'
     ],
     entry_points={
         'console_scripts': [

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,4 @@ sally package
 
 """
 
-__version__ = '0.9.3'  # also change in setup.py
+__version__ = '0.9.4'  # also change in setup.py

--- a/src/sally/core/basing.py
+++ b/src/sally/core/basing.py
@@ -74,4 +74,7 @@ class CueBaser(dbing.LMDBer):
         """
         self.iss.trim()
         self.rev.trim()
+        self.recv.trim()
+        self.revk.trim()
+        self.ack.trim()
         logger.info("Cleared iss and rev escrows")

--- a/src/sally/core/credentials.py
+++ b/src/sally/core/credentials.py
@@ -1,0 +1,58 @@
+from hio.base import doing
+from hio.help import decking
+from keri.core import coring
+from keri import help
+
+logger = help.ogler.getLogger()
+
+
+class TeveryCuery(doing.Doer):
+    """
+    Processes credential revocation cues and records when a given credential was revoked in the local cue database (CueBaser).
+    """
+
+    def __init__(self, cdb, reger, cues=None, **kwa):
+        """
+        Parameters:
+            cdb (CueBaser): instance of CueBaser database
+            reger (Reger): Stores ACDC / TEL events
+            cues (Deck): collection of events (cue) to process
+        """
+        self.cdb = cdb
+        self.reger = reger
+        self.cues = cues if cues is not None else decking.Deck()
+
+        super(TeveryCuery, self).__init__(**kwa)
+
+    def do(self, tymth, *, tock=0.0, **opts):
+        """
+        Iterates over the cues Deck and processes each ACDC revocation cue to save the ACDC sender and revocation time in the cue database.
+
+        Inherited Parameters:
+            tymth (function): closure for read only injection of cycle time in seconds
+            tock (float): cycle time in seconds
+        """
+        self.wind(tymth)  # Set the clock with cycle time function
+        self.tock = tock  # Set the cycle time of this doer
+        yield self.tock   # allow priming of this doer to advance to this line
+
+        while True:
+            while self.cues:
+                cue = self.cues.popleft()
+                if cue['kin'] == "revoked":
+                    serder = cue["serder"]
+                    said = serder.ked["i"]
+                    creder = self.reger.creds.get(said)
+                    if creder is None:
+                        logger.error(f"revocation received for unknown credential {said}")
+
+                    prefixer = coring.Prefixer(qb64=creder.issuer)
+                    saider = coring.Saider(qb64=said)
+                    now = coring.Dater()
+
+                    self.cdb.snd.pin(keys=(saider.qb64,), val=prefixer)
+                    self.cdb.rev.pin(keys=(saider.qb64,), val=now)
+
+                yield self.tock
+
+            yield self.tock

--- a/src/sally/core/serving.py
+++ b/src/sally/core/serving.py
@@ -10,12 +10,10 @@ import os
 import falcon
 from base64 import urlsafe_b64encode as encodeB64
 
-from hio.base import doing
 from hio.core import http
-from hio.help import decking
 from keri import help
 from keri.app import indirecting, storing, notifying
-from keri.core import routing, eventing, coring
+from keri.core import routing, eventing
 from keri.end import ending
 from keri.peer import exchanging
 from keri.vdr import viring, verifying
@@ -23,6 +21,7 @@ from keri.vdr.eventing import Tevery
 from keri.vc import protocoling
 
 from sally.core import handling, basing
+from sally.core.credentials import TeveryCuery
 
 logger = help.ogler.getLogger()
 
@@ -72,7 +71,7 @@ def setup(hby, *, alias, httpPort, hook, auth, listen=False, timeout=10, retry=3
 
     exc = exchanging.Exchanger(hby=hby, handlers=[])
     notifier = notifying.Notifier(hby=hby)
-    # writes notifications for recievced ipex grant exen messages
+    # writes notifications for received IPEX grant exn messages
     protocoling.loadHandlers(hby=hby, exc=exc, notifier=notifier)
     kvy = eventing.Kevery(db=hby.db,
                           lax=True,
@@ -124,48 +123,3 @@ def env_var_to_bool(var_name, default=False):
         return val.lower() in ["true", "1"]
     return default
 
-class TeveryCuery(doing.Doer):
-
-    def __init__(self, cdb, reger, cues=None, **kwa):
-
-        self.cdb = cdb
-        self.reger = reger
-        self.cues = cues if cues is not None else decking.Deck()
-
-        super(TeveryCuery, self).__init__(**kwa)
-
-    def do(self, tymth, *, tock=0.0, **opts):
-        """  Do override to process incoming challenge responses
-
-        Parameters:
-            tymth (function): injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock (float): injected initial tock value
-
-        """
-        # start enter context
-        self.wind(tymth)
-        self.tock = tock
-        yield self.tock
-
-        while True:
-
-            while self.cues:
-                cue = self.cues.popleft()
-                if cue['kin'] == "revoked":
-                    serder = cue["serder"]
-                    said = serder.ked["i"]
-                    creder = self.reger.creds.get(said)
-                    if creder is None:
-                        logger.error(f"revocation received for unknown credential {said}")
-
-                    prefixer = coring.Prefixer(qb64=creder.issuer)
-                    saider = coring.Saider(qb64=said)
-                    now = coring.Dater()
-
-                    self.cdb.snd.pin(keys=(saider.qb64,), val=prefixer)
-                    self.cdb.rev.pin(keys=(saider.qb64,), val=now)
-
-                yield self.tock
-
-            yield self.tock

--- a/tests/core/issuing.py
+++ b/tests/core/issuing.py
@@ -11,6 +11,7 @@ import os
 
 from keri.app import habbing, signing
 from keri.core import coring, parsing, eventing, serdering
+from keri.core import signing as csigning
 from keri.core.eventing import SealEvent
 from keri.vdr import credentialing
 from keri.vdr import verifying
@@ -281,7 +282,7 @@ class CredentialIssuer:
 
 
 def openHab(name, temp, salt):
-    salt = coring.Salter(raw=salt).qb64
+    salt = csigning.Salter(raw=salt).qb64
 
     hby = habbing.Habery(name=name, base="", temp=temp, salt=salt)
     hab = hby.makeHab(name=name, icount=1, isith='1', ncount=1, nsith='1')

--- a/tests/core/test_handling.py
+++ b/tests/core/test_handling.py
@@ -12,7 +12,7 @@ from hio.base import doing, tyming
 from hio.core import http
 from hio.help import decking
 from keri.app import habbing, notifying
-from keri.core import coring, parsing, eventing
+from keri.core import coring, parsing, eventing, signing
 from keri.help import helping
 from keri.peer import exchanging
 from keri.vc import protocoling
@@ -24,7 +24,7 @@ import issuing
 
 
 def test_presentation_handler(seeder, mockHelpingNowUTC):
-    salt = coring.Salter(raw=b'abcdef0123456789').qb64
+    salt = signing.Salter(raw=b'abcdef0123456789').qb64
     with habbing.openHby(name="test", base="test", salt=salt) as hby:
         cdb = basing.CueBaser(name="test_cb")
         exc = exchanging.Exchanger(hby=hby, handlers=[])

--- a/tests/core/test_serving.py
+++ b/tests/core/test_serving.py
@@ -16,7 +16,7 @@ from keri.vdr import eventing as veventing, viring
 from keri.vdr import verifying
 
 import issuing
-from sally.core import basing, serving, handling
+from sally.core import basing, handling, credentials
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -56,7 +56,7 @@ def test_tevery_cuery(seeder, mockHelpingNowUTC):
         cues = decking.Deck()
         serder = veventing.revoke(vcdig=creder.said, regk=creder.regi, dig=creder.said)
         cues.append(dict(kin="revoked", serder=serder))
-        tc = serving.TeveryCuery(cdb=cdb, reger=reger, cues=cues)
+        tc = credentials.TeveryCuery(cdb=cdb, reger=reger, cues=cues)
 
         limit = 1.0
         tock = 0.25


### PR DESCRIPTION
- Upgrades to KERI 1.2.4. 
  - `coring.Ilks` -> `kering.Ilks`
  - `coring.Salter` -> `signing.Salter` and sometimes `signing.Salter` in some places where `keri.app.signing` was also imported.
- Also adds smart package documentation that shows up in Pypi on the project home page.
- Clears out the other three escrows recv, revk, and ack.
- bumps version to 0.9.4
- pegs the test_siginput test to use a fixed salt so the test is deterministic.
- moved the `TeveryCuery` to its own file. Similar refactorings will occur in future PRs.