### PR TITLE
fix: rpy message bug addressed with KERIpy 1.2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
 
 setup(
     name='sally',
-    version='0.10.0',  # also change in src/sally/__init__.py
+    version='0.10.1',  # also change in src/sally/__init__.py
     license='Apache Software License 2.0',
     description='vLEI Audit Reporting API',
     long_description=long_description,
@@ -78,7 +78,7 @@ setup(
     ],
     python_requires='>=3.12.3',
     install_requires=[
-        'keri==1.2.4',
+        'keri==1.2.6',
         'hio==0.6.14',
         'multicommand==1.0.0',
         'blake3==1.0.4',
@@ -95,7 +95,7 @@ setup(
         'pytest-mock-server>=0.3.2'
     ],
     setup_requires=[
-        'setuptools==78.0.2'
+        'setuptools==78.1.0'
     ],
     entry_points={
         'console_scripts': [

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,4 @@ sally package
 
 """
 
-__version__ = '0.10.0'  # also change in setup.py
+__version__ = '0.10.1'  # also change in setup.py


### PR DESCRIPTION
KERIpy 1.2.4 was not sending reply messages due to a logger error in the escrow processing loop. KERIpy 1.2.5+ fix that.