### PR TITLE
Fix first time grant failure bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ webhook URL.
 
 The below `sally server start` command shows how to use Sally, once it has been set up (see below for setup instructions).
 
+Make sure to use the `--direct` argument to start the server up in direct agent mode. This means that the agent will listen on the specified, or default 9723, HTTP port
+for direct HTTP requests. The alternate is to use indirect mode by omitting `--direct` which will cause Sally to rely on any configured witnesses as a communication mailbox (relay).
+
 ```bash
 sally server start \
-  --name sally --alias sally \
+  --direct \
+  --http 9723 \
   --salt 0AD45YWdzWSwNREuAoitH_CC \
+  --name sally \
+  --alias sally \
+  --config-dir scripts \
+  --config-file sally.json \
+  --incept-file sally-incept.json \
   --passcode VVmRdBTe5YCyLMmYRqTAi \
   --web-hook http://127.0.0.1:9923 \
-  --auth EMHY2SRWuqcqlKv2tNQ9nBXyZYqhJ-qrDX70faMcGujF
+  --auth EMCRBKH4Kvj03xbEVzKmOIrg0sosqHUF9VG2vzT9ybzv \
   --loglevel INFO
 ```
 
@@ -205,12 +214,34 @@ KERI_SCRIPT_DIR=./scripts KERI_DEMO_SCRIPT_DIR=./scripts/demo ./scripts/demo/vLE
 Now that you have a sample vLEI ecosystem running you will need to configure and run the Sally server.  
 
 In order to start Sally you will need to either:
-1. Use the `kli init` and `kli incept` commands to create an AID for Sally to use.
-2. (Not yet working) Use the `--incept-file` and `--salt` arguments to instruct the `sally server start` command to create a new identifier, or
+1. Use the `--config-file`, `--config-dir`, `--incept-file`, and `--salt` arguments to instruct the `sally server start` command to create a new identifier, or
+2. Use the `kli init` and `kli incept` commands to create and configure an AID for Sally to use.
 
 Both options require the following configuration files:
 
-### Option 1 - `kli` commands
+### Option 1 - `sally server start` command
+
+Example:
+```bash
+sally server start \
+  --direct \
+  --http 9723 \
+  --salt 0AD45YWdzWSwNREuAoitH_CC \
+  --name sally \
+  --alias sally \
+  --config-dir scripts \
+  --config-file sally.json \
+  --incept-file sally-incept.json \
+  --passcode VVmRdBTe5YCyLMmYRqTAi \
+  --web-hook http://127.0.0.1:9923 \
+  --auth EMCRBKH4Kvj03xbEVzKmOIrg0sosqHUF9VG2vzT9ybzv \
+  --loglevel INFO
+```
+
+You must specify both the keystore (Habery) configuration file and the identifier (Hab) inception file. The `--config-dir` argument applies to both the
+keystore and identifier files. For the keystore configuration the directory `keri/cf` is appended to the value of `--config-file` if it is not an absolute path.
+
+### Option 2 - `kli` commands
  
 Creating an identifier with the `kli init` and `kli incept` commands requires the following two commands to be run from an activated 
 Python virtual environment that has `keripy` configured to run so that the `kli` command is available. 
@@ -233,18 +264,14 @@ Finally, you can start (and leave running) the Sally server with:
 
 ```bash
 sally server start --name sally --alias sally --passcode VVmRdBTe5YCyLMmYRqTAi \
+  --http 9723 \
   --web-hook http://127.0.0.1:9923 \
   --auth EHOuGiHMxJShXHgSb6k_9pqxmRb8H-LT0R2hQouHp8pW
 ```
 
 If you require a sample web hook to receive the notifications from the Sally server one is provided in this repo.  You
 can run the sample hook server in a separate terminal with the following command. The above Sally command assumes this 
-server and port by default. 
-
-### Option 2 (not yet working) - `sally server start` command
-
-You must specify both the keystore (Habery) configuration file and the identifier (Hab) inception file. The `--config-dir` argument applies to both the
-keystore and identifier files. For the keystore configuration the directory `keri/cf` is appended to the value of `--config-file` if it is not an absolute path.
+server and port by default.
 
 #### Configuration Files
 
@@ -305,14 +332,17 @@ The following command will start the Sally server with a new identifier and salt
 
 ```bash
 sally server start \
-  --name sally --alias sally \
+  --direct \
+  --http 9723 \
   --salt 0AD45YWdzWSwNREuAoitH_CC \
+  --name sally \
+  --alias sally \
+  --config-dir scripts \
+  --config-file sally.json \
+  --incept-file sally-incept.json \
   --passcode VVmRdBTe5YCyLMmYRqTAi \
   --web-hook http://127.0.0.1:9923 \
-  --auth EMHY2SRWuqcqlKv2tNQ9nBXyZYqhJ-qrDX70faMcGujF
-  --config-dir scripts \
-  --config-file sally-habery.json \
-  --incept-file sally-incept.json \
+  --auth EMCRBKH4Kvj03xbEVzKmOIrg0sosqHUF9VG2vzT9ybzv \
   --loglevel INFO
 ```
 

--- a/scripts/sally-incept.json
+++ b/scripts/sally-incept.json
@@ -1,9 +1,7 @@
 {
   "transferable": true,
-  "wits": [
-    "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"
-  ],
-  "toad": 1,
+  "wits": [],
+  "toad": 0,
   "icount": 1,
   "ncount": 1,
   "isith": "1",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     python_requires='>=3.12.3',
     install_requires=[
         # This version of KERIpy uses the GLEIF-IT/keripy v1.2.8 branch as of the exn message fix
-        'keri @ git+ssh://git@github.com/GLEIF-IT/keripy.git@e881c9522b9bd38c5d5d5ef04f4e231eb902c36a',
+        'keri @ git+https://github.com/GLEIF-IT/keripy.git@e881c9522b9bd38c5d5d5ef04f4e231eb902c36a',
         'hio==0.6.14',
         'multicommand==1.0.0',
         'blake3==0.4.1',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Pypi Release
 $ pip3 install twine
 
 $ python3 setup.py sdist
-$ twine upload dist/keri-0.0.1.tar.gz
+$ twine upload dist/sally-0.0.1.tar.gz
 
 Create release git:
 $ git tag -a v0.4.2 -m "bump version"
@@ -39,10 +39,12 @@ else:
 
 setup(
     name='sally',
-    version='1.0.0-rc1',  # also change in src/sally/__init__.py
-    license='Apache Software License 2.0',
+    version='1.0.2',  # also change in src/sally/__init__.py
+    license='Apache-2.0',
+    license_files=('LICENSE',),
     description='vLEI Audit Reporting API',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Philip S. Feairheller',
     author_email='pfeairheller@gmail.com',
     url='https://github.com/GLEIF-IT/sally',
@@ -55,7 +57,6 @@ setup(
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
@@ -78,7 +79,8 @@ setup(
     ],
     python_requires='>=3.12.3',
     install_requires=[
-        'cit-keri==1.2.8',
+        # This version of KERIpy uses the GLEIF-IT/keripy v1.2.8 branch as of the exn message fix
+        'keri @ git+ssh://git@github.com/GLEIF-IT/keripy.git@e881c9522b9bd38c5d5d5ef04f4e231eb902c36a',
         'hio==0.6.14',
         'multicommand==1.0.0',
         'blake3==0.4.1',
@@ -89,14 +91,6 @@ setup(
         'test': ['pytest', 'coverage', 'pytest-mock-server'],
         'docs': ['sphinx', 'sphinx-rtd-theme']
     },
-    tests_require=[
-        'coverage==7.7.1',
-        'pytest==8.3.5',
-        'pytest-mock-server==0.3.2'
-    ],
-    setup_requires=[
-        'setuptools==80.3.1'
-    ],
     entry_points={
         'console_scripts': [
             'sally = sally.app.cli.kli:main',

--- a/src/sally/__init__.py
+++ b/src/sally/__init__.py
@@ -6,4 +6,30 @@ sally package
 
 """
 
-__version__ = '1.0.0-rc1'  # also change in setup.py
+__version__ = '1.0.2'  # also change in setup.py
+
+import logging
+
+from hio.help import ogling
+
+from sally.app.logs import TruncatedFormatter
+
+log_name = 'sally'  # name of this project that shows up in log messages
+log_format_str = f'%(asctime)s [{log_name}] %(levelname)-8s %(module)s.%(funcName)s-%(lineno)s %(message)s'
+
+ogler = ogling.initOgler(prefix=log_name, syslogged=False)
+ogler.level = logging.INFO
+
+formatter = TruncatedFormatter(log_format_str)
+formatter.default_msec_format = None
+logHandler = logging.StreamHandler()
+logHandler.setFormatter(formatter)
+ogler.baseFormatter = formatter
+ogler.baseConsoleHandler = logHandler
+ogler.baseConsoleHandler.setFormatter(formatter)
+ogler.reopen(name=log_name, temp=True, clear=True)
+
+def set_log_level(loglevel, logger):
+    """Set the log level for the logger."""
+    ogler.level = logging.getLevelName(loglevel.upper())
+    logger.setLevel(ogler.level)

--- a/src/sally/app/bootstrapping.py
+++ b/src/sally/app/bootstrapping.py
@@ -1,0 +1,82 @@
+from typing import Callable
+
+from hio.base import doing
+from keri.app import habbing, oobiing
+
+from sally import ogler, log_name
+
+logger = ogler.getLogger(log_name)
+
+
+class BootstrapRunner(doing.DoDoer):
+    def __init__(self, hby: habbing.Habery, tymth: Callable):
+        """
+        Parameters:
+            hby (Habery): the hab in which to create the AID, if needed
+            tymth (function): the clock time (scheduler tick rate) to use from the parent Doist
+        """
+        self.hby = hby
+        self.complete = False
+        super(BootstrapRunner, self).__init__(tymth=tymth)
+        self.extend([OobiResolveBootstrapper(hby, self)])
+
+    def recur(self, tyme, deeds=None):
+        if self.complete:
+            return True
+        super(BootstrapRunner, self).recur(tyme, deeds)
+        return False
+
+    def configureAndIncept(self):
+        """Configure a keystore by resolving OOBIs in config"""
+        self.extend(OobiResolveBootstrapper(self.hby, self))
+
+class OobiResolveBootstrapper(doing.Doer):
+    """
+    Bootstraps OOBI Resolutions for a Habery and an AID, resolving all OOBIs in the bootstrap configuration file.
+    """
+
+    def __init__(self, hby: habbing.Habery, parent: BootstrapRunner, tock=0.0, **kwa):
+        self.hby = hby
+        self.parent = parent
+        super(OobiResolveBootstrapper, self).__init__(tock=tock, **kwa)
+
+    def configure_and_incept(self):
+        oobi_count = self.hby.db.oobis.cntAll()
+        if oobi_count:
+            obi = oobiing.Oobiery(hby=self.hby)
+            self.parent.extend(obi.doers)
+
+            while oobi_count > self.hby.db.roobi.cntAll():
+                yield 0.25
+
+            for (oobi,), obr in self.hby.db.roobi.getItemIter():
+                if obr.state in (oobiing.Result.resolved,):
+                    logger.info(f"{oobi} succeeded")
+                if obr in (oobiing.Result.failed,):
+                    logger.error(f"{oobi} failed")
+
+            self.parent.remove(obi.doers)
+
+        wc = [oobi for (oobi,), _ in self.hby.db.woobi.getItemIter()]
+        if len(wc) > 0:
+            logger.info(f"\nAuthenticating Well-Knowns...")
+            authn = oobiing.Authenticator(hby=self.hby)
+            self.parent.extend(authn.doers)
+
+            while True:
+                cap = []
+                for (_,), wk in self.hby.db.wkas.getItemIter(keys=b''):
+                    cap.append(wk.url)
+
+                if set(wc) & set(cap) == set(wc):
+                    break
+
+                yield 0.5
+
+            self.parent.remove(authn.doers)
+
+        self.parent.complete = True
+
+    def recur(self, tock=0.0, **opts):
+        yield from self.configure_and_incept()
+        return True

--- a/src/sally/app/cli/commands/hook/demo.py
+++ b/src/sally/app/cli/commands/hook/demo.py
@@ -12,10 +12,11 @@ from hio.core import http
 from keri import help
 from keri.app import directing
 
+from sally import log_name, ogler
 from sally.core import handling, httping
 from sally.core.monitoring import HealthEnd
 
-logger = help.ogler.getLogger()
+logger = ogler.getLogger(log_name)
 
 parser = argparse.ArgumentParser(description='Launch SALLY sample web hook server')
 parser.set_defaults(handler=lambda args: launch(args),

--- a/src/sally/app/cli/commands/server/start.py
+++ b/src/sally/app/cli/commands/server/start.py
@@ -4,14 +4,14 @@ sally.cli.commands module
 
 """
 import argparse
-import logging
 import os
 
-from keri import help
-from keri.app import keeping, habbing, directing, configing, oobiing
+from hio.base import doing
+from keri.app import keeping, habbing, configing
 from keri.app.cli.common import existing
 
 import sally
+from sally import ogler, log_name, set_log_level
 from sally.core import serving
 
 parser = argparse.ArgumentParser(description='Launch Sally vLEI credential presentation receiver service.')
@@ -64,19 +64,15 @@ parser.add_argument(
     "-l", "--loglevel", action="store", required=False, default=os.getenv("SALLY_LOG_LEVEL", "INFO"),
     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 
-help.ogler.level = logging.getLevelName(logging.INFO)
-logger = help.ogler.getLogger()
+
+logger = ogler.getLogger(log_name)
 
 def launch(args, expire=0.0):
     """Launch Sally vLEI credential presentation receiver service"""
     # Logging config
-    base_formatter = logging.Formatter('%(asctime)s [sally] %(levelname)-8s %(message)s')
-    base_formatter.default_msec_format = None
-    help.ogler.baseConsoleHandler.setFormatter(base_formatter)
-    help.ogler.level = logging.getLevelName(args.loglevel.upper())
-    logger.setLevel(help.ogler.level)
-    help.ogler.reopen(name="sally", temp=True, clear=True)
+    set_log_level(args.loglevel, logger)
 
+    # Parse arguments
     hook = args.web_hook
     name = args.name
     salt = args.salt

--- a/src/sally/app/cli/commands/server/start.py
+++ b/src/sally/app/cli/commands/server/start.py
@@ -12,6 +12,7 @@ from keri.app.cli.common import existing
 
 import sally
 from sally import ogler, log_name, set_log_level
+from sally.app.bootstrapping import BootstrapRunner
 from sally.core import serving
 
 parser = argparse.ArgumentParser(description='Launch Sally vLEI credential presentation receiver service.')
@@ -99,6 +100,18 @@ def launch(args, expire=0.0):
         "incept_file": incept_file, "config_dir": config_dir
     }
 
+    hby = init_habery(name=name, base=base, bran=bran, config_file=config_file,
+                      config_dir=config_dir, salt=salt)
+    hab = serving.incept_if_new(hby, alias, incept_args)
+
+    # setup doers
+    doers = serving.setupDoers(hby, hab, alias=alias, http_port=http_port, hook=hook, auth=auth,
+                           timeout=timeout, retry=retry, direct=direct, incept_args=incept_args)
+    logger.info(f"Sally Server v{sally.__version__} listening on {http_port} with DB version {hby.db.version}")
+    serving.run_doers(doers)
+
+def init_habery(name, base, bran, config_file, config_dir, salt):
+    """Initialize or reopen the Habery (keystore)"""
     ks = keeping.Keeper(name=name, base=base, temp=False, reopen=True)
     aeid = ks.gbls.get('aeid')
 
@@ -109,17 +122,13 @@ def launch(args, expire=0.0):
                                     temp=False, reopen=True, clear=False)
         habery_cfg = dict()
         habery_cfg["salt"] = salt if salt else None # When None causes Habery to randomize salt
-        hby = habbing.Habery(name=name, base=base, bran=bran, cf=cf, **habery_cfg)
+        hby = habbing.Habery(name=name, base=base, bran=bran, cf=cf, ks=ks, **habery_cfg)
     else:
+        ks.close() # existing.setupHby reopens, so close here to avoid LMDB conflict.
         hby = existing.setupHby(name=name, base=base, bran=bran)
 
-    # setup doers
-    hbyDoer = habbing.HaberyDoer(habery=hby)
-    obl = oobiing.Oobiery(hby=hby)
-
-    doers = [hbyDoer, *obl.doers]
-    doers += serving.setup(hby, alias=alias, httpPort=http_port, hook=hook, auth=auth,
-                           timeout=timeout, retry=retry, direct=direct, incept_args=incept_args)
-
-    logger.info(f"Sally Server v{sally.__version__} listening on {http_port} with DB version {hby.db.version}")
-    directing.runController(doers=doers, expire=expire)
+    # Resolve OOBIs for the Habery and the new Hab
+    bootstrap_doist = doing.Doist(limit=0.0, tock=0.03125, real=True)
+    runner = BootstrapRunner(hby=hby, tymth=bootstrap_doist.tymen())
+    bootstrap_doist.do(doers=[runner])
+    return hby

--- a/src/sally/app/logs.py
+++ b/src/sally/app/logs.py
@@ -1,0 +1,30 @@
+import logging
+
+
+class TruncatedFormatter(logging.Formatter):
+    """
+    Formats log records with shorter module and function names and a right justified line number for readability.
+
+    Example:
+        "2025-09-05 13:59:29 [keria] INFO     serving    .runAgency       -  145 The Agency is loaded and waiting for requests..."
+    """
+
+    def __init__(self, fmt=None, datefmt=None, style='%'):
+        super().__init__(fmt, datefmt, style)
+
+    def format(self, record):
+        """
+        Format the log record with truncated module and function names.
+        Ignores exceptions and logs an error if formatting fails.
+        """
+        # Truncate module and funcName to first 'chars' characters
+        mod_chars = 10  # number of spaces to truncate to
+        fn_chars = 14  # number of spaces to truncate to
+        record.module = (record.module[:mod_chars] + ' ' * mod_chars)[:mod_chars]
+        record.funcName = (record.funcName[:fn_chars] + ' ' * fn_chars)[:fn_chars]
+        record.lineno = str(record.lineno).rjust(5)  # Ensure line number is right-aligned
+        try:
+            return super().format(record)
+        except Exception as e:
+            logging.error(f'Error formatting log record: {e}')
+            raise e

--- a/src/sally/core/basing.py
+++ b/src/sally/core/basing.py
@@ -5,11 +5,12 @@ sally.core.basing module
 
 Database support
 """
-from keri import help
 from keri.core import coring, serdering
 from keri.db import dbing, subing
 
-logger = help.ogler.getLogger()
+from sally import log_name, ogler
+
+logger = ogler.getLogger(log_name)
 
 class CueBaser(dbing.LMDBer):
     """

--- a/src/sally/core/credentials.py
+++ b/src/sally/core/credentials.py
@@ -1,9 +1,10 @@
 from hio.base import doing
 from hio.help import decking
 from keri.core import coring
-from keri import help
 
-logger = help.ogler.getLogger()
+from sally import ogler, log_name
+
+logger = ogler.getLogger(log_name)
 
 
 class TeveryCuery(doing.Doer):

--- a/src/sally/core/handling.py
+++ b/src/sally/core/handling.py
@@ -14,14 +14,16 @@ from urllib import parse
 from hio.base import doing, Doer
 from hio.core import http
 from hio.help import Hict
-from keri import help, kering
+from keri import kering
 from keri.core import coring
 from keri.peer import exchanging
 from keri.end import ending
 from keri.help import helping
+
+from sally import ogler, log_name
 from sally.core import httping
 
-logger = help.ogler.getLogger()
+logger = ogler.getLogger(log_name)
 
 # vLEI ACDC schema SAIDs
 QVI_SCHEMA = "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"

--- a/src/sally/core/serving.py
+++ b/src/sally/core/serving.py
@@ -6,14 +6,17 @@ sally.core.serving module
 Endpoint service
 """
 import os
+from typing import List
 
 import falcon
 from base64 import urlsafe_b64encode as encodeB64
 
+from hio.base import doing, Doer
 from hio.core import http
 from hio.help import decking
 from keri.app import indirecting, storing, notifying, habbing, oobiing
 from keri.app.cli.commands import incept
+from keri.app.habbing import Habery, Hab
 from keri.core import routing, eventing, parsing
 from keri.end import ending
 from keri.peer import exchanging
@@ -26,10 +29,62 @@ from sally.core import handling, basing, monitoring, httping
 from sally.core.credentials import TeveryCuery
 from sally.core.verifying import VerificationAgent
 
-logger = help.ogler.getLogger()
 logger = ogler.getLogger(log_name)
 
-def setup(hby, *, alias, httpPort, hook, auth, timeout=10, retry=3, direct=True, incept_args=None):
+def incept_if_new(hby: Habery, alias: str, incept_args: dict):
+    """
+    Create an identifier with the specified alias if it does not exist.
+    This is run in a separate scheduler (Doist) prior to starting Sally so that the identifier can
+    exist and have all Habery configuration OOBIs resolved.
+
+    Warning: This only supports no witness, single sig identifiers as it is assumed it will be used
+        with the direct-mode verification agent.
+    """
+    if incept_args is None:
+        incept_args = {}
+    hab = hby.habByName(name=alias)
+    if hab is None:
+        # Incept the new Hab
+        if incept_args["incept_file"] is None:
+            raise ValueError("incept file by arg --incept-file is required to create a new identifier")
+        logger.info(f"Making new hab {alias} in Habery {incept_args.get('name', '')}")
+        hab = hby.makeHab(name=alias, **inception_config(**incept_args))
+    else:
+        logger.info(f"Hab '{alias}' already exists, using...")
+    return hab
+
+def run_doers(doers: List[Doer], expire=0.0):
+    """Runs the verifier in a Doist until the specified expire time (in seconds)."""
+    tock = 0.03125
+    doist = doing.Doist(limit=expire, tock=tock, real=True)
+    doist.do(doers=doers)
+
+
+def setupDoers(
+        hby: Habery, hab: Hab, alias: str, http_port: int, hook: str, auth: str,
+        timeout: int = 10, retry: int = 3, direct: bool = True, incept_args: dict = None):
+    """
+    Parameters:
+        hby (Habery): identifier database environment
+        alias (str): alias of the identifier representing this agent
+        httpPort (int): external port to listen on for HTTP messages
+        hook (str): URL of external web hook to notify of credential issuance and revocations
+        auth (str): alias or AID of external authority for contacts and credentials
+        timeout (int): escrow timeout (in minutes) for events not delivered to upstream web hook
+        retry (int): retry delay (in seconds) for failed web hook attempts
+        direct (bool): listen for direct-mode messages on HTTP port or use indirect-mode mailbox
+        incept_args (dict): arguments for incepting Sally's identifier if it does not exist
+    """
+    hbyDoer = habbing.HaberyDoer(habery=hby)
+    obl = oobiing.Oobiery(hby=hby)
+
+    doers = [hbyDoer, *obl.doers]
+    doers += setup(hby, hab, alias=alias, httpPort=http_port, hook=hook, auth=auth, timeout=timeout,
+                   retry=retry, direct=direct)
+    return doers
+
+def setup(hby: Habery, hab: Hab, alias: str, httpPort: int, hook: str, auth: str, timeout=10,
+          retry=3, direct=True):
     """
     Setup components, HTTP endpoints, and MailboxDirector working with witnesses to receive events.
 
@@ -42,20 +97,10 @@ def setup(hby, *, alias, httpPort, hook, auth, timeout=10, retry=3, direct=True,
         timeout (int): escrow timeout (in minutes) for events not delivered to upstream web hook
         retry (int): retry delay (in seconds) for failed web hook attempts
         direct (bool): listen for direct-mode messages on HTTP port or use indirect-mode mailbox
-        incept_args (dict): arguments for incepting Sally's identifier if it does not exist
     """
     cues = decking.Deck()
-    # make hab
-    if incept_args is None:
-        incept_args = {}
-    hab = hby.habByName(name=alias)
     if hab is None:
-        if incept_args["incept_file"] is None:
-            raise ValueError("incept file by arg --incept-file is required to create a new identifier")
-        logger.info(f"Making new hab {alias} in Habery {incept_args.get('name', '')}")
-        hab = hby.makeHab(name=alias, **inception_config(**incept_args))
-    else:
-        logger.info(f"Hab '{alias}' already exists, using...")
+        raise ValueError(f"Identifier with alias '{alias}' does not exist. It must be created before starting Sally.")
 
     logger.info(f"Using hab {hab.name}:{hab.pre}")
     logger.info(f"\tCESR Qualifed Base64 Public Key:  {hab.kever.serder.verfers[0].qb64}")
@@ -97,7 +142,7 @@ def setup(hby, *, alias, httpPort, hook, auth, timeout=10, retry=3, direct=True,
 
     ending.loadEnds(app, hby=hby, default=hab.pre)
 
-    doers = [httpServerDoer, comms, tc]
+    doers: List[Doer] = [httpServerDoer, comms, tc]
     if direct:
         logger.info("Adding direct mode HTTP listener")
         # reading notifications for received ipex grant exn messages
@@ -106,7 +151,7 @@ def setup(hby, *, alias, httpPort, hook, auth, timeout=10, retry=3, direct=True,
         # Set up HTTP endpoint for PUT-ing application/cesr streams to the SallyAgent at '/'
         httpEnd = indirecting.HttpEnd(rxbs=parser.ims, mbx=mbx)
         app.add_route('/', httpEnd)
-        agent = VerificationAgent(hab=hab, parser=parser, kvy=kvy, tvy=tvy, rvy=rvy, exc=exc, cues=cues)
+        agent = VerificationAgent(hab=hab, parser=parser, kvy=kvy, tvy=tvy, rvy=rvy, verifier=verifier, exc=exc, cues=cues)
         doers.append(agent)
     else:
         logger.info("Adding indirect mode mailbox listener")

--- a/src/sally/core/serving.py
+++ b/src/sally/core/serving.py
@@ -12,8 +12,7 @@ from base64 import urlsafe_b64encode as encodeB64
 
 from hio.core import http
 from hio.help import decking
-from keri import help
-from keri.app import indirecting, storing, notifying
+from keri.app import indirecting, storing, notifying, habbing, oobiing
 from keri.app.cli.commands import incept
 from keri.core import routing, eventing, parsing
 from keri.end import ending
@@ -22,11 +21,13 @@ from keri.vdr import viring, verifying
 from keri.vdr.eventing import Tevery
 from keri.vc import protocoling
 
+from sally import ogler, log_name
 from sally.core import handling, basing, monitoring, httping
 from sally.core.credentials import TeveryCuery
 from sally.core.verifying import VerificationAgent
 
 logger = help.ogler.getLogger()
+logger = ogler.getLogger(log_name)
 
 def setup(hby, *, alias, httpPort, hook, auth, timeout=10, retry=3, direct=True, incept_args=None):
     """

--- a/src/sally/core/verifying.py
+++ b/src/sally/core/verifying.py
@@ -13,16 +13,27 @@ class VerificationAgent(doing.DoDoer):
     Indirect mode is used when presenting to the reporting agent via a mailbox whether from a witness or a mailbox agent.
     """
 
-    def __init__(self, hab, parser, kvy, tvy, rvy, exc, cues=None, **opts):
+    def __init__(self, hab, parser, kvy, tvy, rvy, verifier, exc, cues=None, **opts):
         """
         Initializes the ReportingAgent with an identifier (Hab), parser, KEL, TEL, and Exchange message processor
         so that it can process incoming credential presentations.
+
+        Parameters:
+            hab (Hab): The identifier (Hab) for the reporting agent.
+            parser (Parser): The message parser to handle incoming messages.
+            kvy (Kevery): The KEL message processor for handling key events.
+            tvy (Tevery): The TEL message processor for handling registry and credential events.
+            rvy (Revery): The Reply message processor for handling location, endrole, and other reply of messages.
+            verifier (Verifier): The Credential processor for handling credential escrows.
+            exc (Exchanger): The Exchanger for managing exchange messages.
+            cues (Deck, optional): A data buffer for inter-component communication cues. Defaults to an empty deck
         """
         self.hab = hab
         self.parser = parser
         self.kvy = kvy
         self.tvy = tvy
         self.rvy = rvy
+        self.verifier = verifier
         self.exc = exc
         self.cues = cues if cues is not None else decking.Deck()
         doers = [doing.doify(self.msgDo), doing.doify(self.escrowDo)]
@@ -56,6 +67,8 @@ class VerificationAgent(doing.DoDoer):
             self.rvy.processEscrowReply()
             if self.tvy is not None:
                 self.tvy.processEscrows()
+            if self.verifier is not None:
+                self.verifier.processEscrows()
             self.exc.processEscrow()
 
             yield

--- a/src/sally/core/verifying.py
+++ b/src/sally/core/verifying.py
@@ -1,9 +1,9 @@
 from hio.base import doing
 from hio.help import decking
-from keri import help
+from sally import ogler, log_name
 
 
-logger = help.ogler.getLogger()
+logger = ogler.getLogger(log_name)
 
 
 class VerificationAgent(doing.DoDoer):

--- a/tests/core/test_basing.py
+++ b/tests/core/test_basing.py
@@ -3,11 +3,11 @@
 tests.db.dbing module
 
 """
-import lmdb
 import os
 
+import lmdb
 from keri.db import subing
-from keri.vc import proving
+
 from sally.core import basing
 
 

--- a/tests/core/test_httping.py
+++ b/tests/core/test_httping.py
@@ -9,9 +9,7 @@ from base64 import urlsafe_b64decode as decodeB64
 
 from hio.help import Hict
 from http_sfv import Dictionary
-from keri import core
 from keri.app import habbing
-from keri.core import coring
 from keri.end import ending
 
 from sally.core import httping


### PR DESCRIPTION
This does a few things with the most important being upgrading to GLEIF-IT/keripy 1.2.8 including the [exchange message processing fix](https://github.com/GLEIF-IT/keripy/commit/4b2d906355fd830cd34b2c741772881a591b5557)

Other parts:
1. Cleaned up imports
2. Cleaned up logging with consistent root level module `ogler` usage and pulled in the `TruncatedFormatter` from vLEI-Server and KERIA.
3. Refactored server setup to return a list of Doers so using it from an end-to-end system simulation test in SignifyPy is easy.
4. Added a config bootstrapper so that `sally server start ...` is all you have to do, like the following command:

```bash
sally server start \
  --direct \
  --http 9723 \
  --salt 0AD45YWdzWSwNREuAoitH_CC \
  --name sally \
  --alias sally \
  --config-dir scripts \
  --config-file sally.json \
  --incept-file sally-incept.json \
  --passcode VVmRdBTe5YCyLMmYRqTAi \
  --web-hook http://127.0.0.1:9923 \
  --auth EMCRBKH4Kvj03xbEVzKmOIrg0sosqHUF9VG2vzT9ybzv \
  --loglevel INFO
```