### PR TITLE
Automate Sally release publishing

### DIFF
--- a/.github/workflows/publish-sally.yml
+++ b/.github/workflows/publish-sally.yml
@@ -1,43 +1,240 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
-name: Publish Docker image
+name: Publish Sally release
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish
+        required: true
+        type: string
+      mirror_dockerhub:
+        description: Mirror the GHCR image to Docker Hub
+        required: true
+        default: true
+        type: boolean
+
+run-name: Publish Sally ${{ github.event.release.tag_name || inputs.tag }}
+
+concurrency:
+  group: publish-sally-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  verify:
+    name: Verify signed release tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.tag.outputs.commit }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - name: Verify tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must be a stable semantic version"
+            exit 1
+          fi
+
+          ref=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG")
+          if [[ $(jq -r '.object.type' <<<"$ref") != "tag" ]]; then
+            echo "::error::Release tag must be an annotated tag"
+            exit 1
+          fi
+
+          tag=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/tags/$(jq -r '.object.sha' <<<"$ref")")
+          if [[ $(jq -r '.verification.verified' <<<"$tag") != "true" ||
+                $(jq -r '.verification.reason' <<<"$tag") != "valid" ]]; then
+            echo "::error::Release tag must have a valid GitHub-verified signature"
+            exit 1
+          fi
+          if [[ $(jq -r '.object.type' <<<"$tag") != "commit" ]]; then
+            echo "::error::Release tag must point directly to a commit"
+            exit 1
+          fi
+
+          release=$(gh api \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")
+          if [[ $(jq -r '.draft' <<<"$release") != "false" ||
+                $(jq -r '.prerelease' <<<"$release") != "false" ||
+                $(jq -r '.published_at' <<<"$release") == "null" ]]; then
+            echo "::error::Tag must have a published stable GitHub Release"
+            exit 1
+          fi
+
+          echo "commit=$(jq -r '.object.sha' <<<"$tag")" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+  release-assets:
+    name: Mirror PyPI files
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download files from PyPI
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import shutil
+          import urllib.request
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          url = f"https://pypi.org/pypi/sally/{version}/json"
+          with urllib.request.urlopen(url) as response:
+              metadata = json.load(response)
+
+          files = [
+              item for item in metadata["urls"]
+              if item["packagetype"] in {"bdist_wheel", "sdist"}
+          ]
+          if len(files) != 2 or {item["packagetype"] for item in files} != {
+              "bdist_wheel", "sdist"
+          }:
+              raise SystemExit("Expected exactly one wheel and one source archive")
+
+          destination = Path("dist")
+          destination.mkdir()
+          for item in files:
+              filename = item["filename"]
+              if Path(filename).name != filename:
+                  raise SystemExit(f"Unsafe PyPI filename: {filename}")
+              path = destination / filename
+              with urllib.request.urlopen(item["url"]) as response, path.open("wb") as output:
+                  shutil.copyfileobj(response, output)
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              if digest != item["digests"]["sha256"]:
+                  raise SystemExit(f"Hash mismatch for {filename}")
+              print(f"{digest}  {filename}")
+          PY
+
+      - name: Check distributions
+        run: |
+          python -m pip install --disable-pip-version-check twine==6.2.0
+          python -m twine check dist/*
+
+      - name: Attach files to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        run: >-
+          gh release upload "$RELEASE_TAG" dist/* --clobber
+          --repo "$GITHUB_REPOSITORY"
+
+  image:
+    name: Publish multi-platform image
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify.outputs.commit }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Create image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/gleif-it/sally
+          tags: |
+            type=raw,value=${{ needs.verify.outputs.version }}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.verify.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.verify.outputs.commit }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: containers/sally.dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          provenance: mode=max
+
+      - name: Attest image
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-name: ghcr.io/gleif-it/sally
+          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-version: ${{ needs.verify.outputs.version }}
+          push-to-registry: true
+
+  dockerhub:
+    name: Mirror image to Docker Hub
+    if: github.event_name == 'release' || inputs.mirror_dockerhub
+    needs: [verify, image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: gleif/sally
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          file: containers/sally.dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Mirror image
+        env:
+          DIGEST: ${{ needs.image.outputs.digest }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "docker.io/gleif/sally:$VERSION" \
+            --tag "docker.io/gleif/sally:latest" \
+            "ghcr.io/gleif-it/sally@$DIGEST"


### PR DESCRIPTION
## Summary

- require a published stable release with a valid signed annotated tag
- mirror the exact PyPI wheel and source archive onto the GitHub Release
- build one amd64/arm64 image for GHCR, attest it, and optionally mirror its manifest to Docker Hub
- pin every third-party action to the requested release SHA

## Validation

- Actionlint 1.7.12
- 6 tests passed on Python 3.12.10
- fatal Flake8: 0 violations
- `git diff --check`

For the 1.0.5 backfill, dispatch with `mirror_dockerhub=false`; the existing Docker Hub image remains untouched. Refresh `DOCKER_USERNAME` and `DOCKER_PASSWORD` before the next automatic release.